### PR TITLE
Add a cljs repl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ pom.xml
 pom.xml.asc
 **/gen
 **/target
+out
 .*
 !.gitignore

--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
-## Introduction
+## What is this
 
-A play-cljs game in which ... well, that part is up to you. Do `boot run` to develop and `boot build` to compile a release version.
+A turn-based tactical game... in space!
 
+## How do I work on it
+
+### Development
+
+To run a development server with file watching, run `boot run`.
+
+You can get a repl for Clojure files (.clj, .cljc) with `boot repl`. Run it from
+the project root.
+
+To get a Clojurescript repl, run `boot cljsrepl`. In another tab, run `boot
+repl -c` to start a client-only repl. In that repl, run `(start-repl)`. Load
+the application in a browser (localhost:3000), and in the repl client you
+should see a "connected!" message after a moment, and now you should be able to
+require cljs files and send javascript to the browser. (Note: incognito windows
+do not seem to work at the moment.)

--- a/build.boot
+++ b/build.boot
@@ -3,6 +3,10 @@
   :resource-paths #{"resources"}
   :dependencies '[[org.clojure/clojure "1.9.0" :scope "provided"]
                   [adzerk/boot-cljs "2.1.4" :scope "test"]
+                  [adzerk/boot-cljs-repl   "0.3.3"]
+                  [com.cemerick/piggieback "0.2.1"  :scope "test"]
+                  [weasel                  "0.7.0"  :scope "test"]
+                  [org.clojure/tools.nrepl "0.2.12" :scope "test"]
                   [adzerk/boot-reload "0.5.2" :scope "test"]
                   [pandeiro/boot-http "0.8.3" :scope "test"]
                   [javax.xml.bind/jaxb-api "2.3.0" :scope "test"] ; necessary for Java 9 compatibility
@@ -13,8 +17,8 @@
                   [edna "1.2.0"]])
 
 (require
-  '[nightlight.boot :refer [nightlight]]
   '[adzerk.boot-cljs :refer [cljs]]
+  '[adzerk.boot-cljs-repl :refer [cljs-repl start-repl]]
   '[adzerk.boot-reload :refer [reload]]
   '[pandeiro.boot-http :refer [serve]])
 
@@ -27,10 +31,20 @@
     (cljs
       :optimizations :none
       :compiler-options {:asset-path "main.out"})
-    (target)
-    (nightlight :port 4000 :url "http://localhost:3000")))
+    (target)))
+
+(deftask cljsrepl []
+  (set-env! :resource-paths #(conj % "dev-resources"))
+  (comp
+    (serve :dir "target/public" :port 3000)
+    (watch)
+    (reload)
+    (cljs-repl)
+    (cljs
+      :optimizations :none
+      :compiler-options {:asset-path "main.out"})
+    (target)))
 
 (deftask build []
   (set-env! :resource-paths #(conj % "prod-resources"))
   (comp (cljs :optimizations :advanced) (target)))
-


### PR DESCRIPTION
Not knowing how to do development on a clojurescript project, I
investigated how to use a clojurescript repl with boot. Added a task
to do it to the build.boot file and instructions on how to use it to the
README. I wish it were simpler, but this does seem to be the prescribed
workflow.

This is also making me more sure that we should put whatever code we can
into cljc files, to make them useable from typical clojure tooling,
it'll be more comfortable to work with I think.

Also removed the nightlight call in the run task since we don't use it.